### PR TITLE
fix: pass ClientID to MSI auth if it exists

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,17 +38,14 @@ linters-settings:
   gocyclo:
     min-complexity: 15
   goimports: {}
-  golint:
-    min-confidence: 0
+  revive:
+    confidence: 0
   gofmt:
     simplify: true
-  gomnd:
-    settings:
-      mnd:
-        # don't include the "operation" and "assign"
-        checks: [argument, case, condition, return]
+  mnd:
+    # don't include the "operation" and "assign"
+    checks: [argument, case, condition, return]
   govet:
-    check-shadowing: true
     settings:
       printf:
         funcs:
@@ -59,11 +56,8 @@ linters-settings:
           - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Fatalf
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
   misspell: {}
   nolintlint:
-    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
     allow-unused: false # report any unused nolint directives
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
@@ -74,7 +68,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - errcheck
     - gofmt
@@ -84,20 +77,21 @@ linters:
     - gosimple
     - ineffassign
     - misspell
+    - mnd
     - nakedret
     - rowserrcheck
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - revive
     - gocritic
     - govet
     - dupl
 issues:
+  exclude-dirs:
+    - cmd/docs
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     #    - path: _test\.go
@@ -113,11 +107,5 @@ issues:
 
 run:
   timeout: 30m
-  skip-dirs:
-    - cmd/docs
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.42.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,15 @@
 linters-settings:
   depguard:
-    list-type: blacklist
-    packages:
-      - github.com/jenkins-x/jx/v2/pkg/log/
-      - github.com/satori/go.uuid
-      - github.com/pborman/uuid
-    packages-with-error-message:
-      - github.com/jenkins-x/jx/v2/pkg/log/: "use jenkins-x/jx-logging instead"
-      - github.com/satori/go.uuid: "use github.com/google/uuid instead"
-      - github.com/pborman/uuid: "use github.com/google/uuid instead"
+    rules:
+      main:
+        list-mode: original
+        deny:
+        - pkg: github.com/jenkins-x/jx/v2/pkg/log
+          desc: "use jenkins-x/jx-logging instead"
+        - pkg: github.com/satori/go.uuid
+          desc: "use github.com/google/uuid instead"
+        - pkg: github.com/pborman/uuid
+          desc: "use github.com/google/uuid instead"
   dupl:
     threshold: 100
   exhaustive:

--- a/pkg/iam/azureiam/iam.go
+++ b/pkg/iam/azureiam/iam.go
@@ -43,6 +43,7 @@ func NewEnvironmentCredentials() (Credentials, error) {
 		return &environmentCredentials{
 			tenantID:           settings.Values[auth.TenantID],
 			subscriptionID:     settings.Values[auth.SubscriptionID],
+			clientID:           settings.Values[auth.ClientID],
 			useManagedIdentity: true,
 		}, nil
 	}
@@ -154,12 +155,9 @@ func GetKeyvaultAuthorizer(creds Credentials) (autorest.Authorizer, error) {
 		a = autorest.NewBearerAuthorizer(token)
 
 	case OAuthGrantTypeManagedIdentity:
-		MIEndpoint, err := adal.GetMSIVMEndpoint()
-		if err != nil {
-			return nil, err
-		}
-
-		token, err := adal.NewServicePrincipalTokenFromMSI(MIEndpoint, vaultEndpoint)
+		token, err := adal.NewServicePrincipalTokenFromManagedIdentity(vaultEndpoint, &adal.ManagedIdentityOptions{
+			ClientID: creds.ClientID(),
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/secretstore/vaultsecrets/vaultsecrets_test.go
+++ b/pkg/secretstore/vaultsecrets/vaultsecrets_test.go
@@ -83,7 +83,7 @@ func TestNewVaultSecretManager(t *testing.T) {
 	}
 
 	// Start a server to mimic kubernetes cluster
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		// Send response to be tested
 		// If you decode the test json, then the value of kubernetes.io/serviceaccount/service-account.uid is 424d91ce-20e3-48a2-b1e5-394e6a0c1813
 		_, _ = rw.Write([]byte(`{"status": {"authenticated": true, "user":{"uid":"424d91ce-20e3-48a2-b1e5-394e6a0c1813","username": "system:serviceaccount:secret-infra:default"}}}`))


### PR DESCRIPTION
Seeing issues with the boot-job failing to populate secrets on initial startup of a new cluster with nodes where multiple identities exist.

```
Error: failed to populate secrets: failed to save properties key: jx-admin-user properties: password, username on ExternalSecret jenkins-x-chartmuseum: unable to create key ops client: azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://<REDACTED>: StatusCode=400 -- Original Error: adal: Refresh request failed. Status Code = '400'. Response body: {"error":"invalid_request","error_description":"Multiple user assigned identities exist, please specify the clientId / resourceId of the identity in the token request"} Endpoint http://<REDACTED>
```

These changes allow the `ClientID` of the correct identity to be specified by env var when getting the service principal token. `ClientID` is an optional parameter so won't affect clusters where only one service principal exists.

Also moved to new adal functions as existing where deprecated.